### PR TITLE
Change freeshipping value

### DIFF
--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -107,7 +107,3 @@ const MinicartFreeshipping: FunctionComponent = () => {
   return <MinimumFreightValue settings={settings} />
 }
 export default MinicartFreeshipping
-
-
-
-Hola! Somos dos chicas y trabajamos en empresas de tecnología en Barcelona. Estamos buscando un piso para nosotras y dos y nos interesaría ver el piso. Cuando podíamos pasar a verlo? Gracias y un saludo!

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -80,6 +80,7 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
                 <FormattedCurrency
                   value={Math.max(0, differenceBetwenValues)}
                 />
+                !
               </span>
             </p>
           ) : (

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -25,11 +25,8 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   const [shippingFreePercentage, setShippingFreePercentage] = useState(0)
   const [differenceBetwenValues, setDifferenceBetwenValues] = useState(0)
   const {
-    orderForm: { totalizers },
+    orderForm: { totalizers, value },
   } = useOrderForm()
-
-  const valueWithDiscount =
-    Number(totalizers[0].value) + Number(totalizers[1].value)
 
   const handleUpdateMinicartValue = useCallback(
     val => {
@@ -38,6 +35,10 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
     },
     [settings.freeShippingAmount]
   )
+
+  const valueWithDiscount = value
+    ? Number(totalizers[0]?.value) + Number(totalizers[1]?.value)
+    : value
 
   useEffect(() => {
     handleUpdateMinicartValue(valueWithDiscount)
@@ -103,6 +104,7 @@ const MinicartFreeshipping: FunctionComponent = () => {
 
   if (!settings.freeShippingAmount) {
     console.warn('No Free Shipping amount set')
+
     return null
   }
   return <MinimumFreightValue settings={settings} />

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -25,8 +25,11 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   const [shippingFreePercentage, setShippingFreePercentage] = useState(0)
   const [differenceBetwenValues, setDifferenceBetwenValues] = useState(0)
   const {
-    orderForm: { value },
+    orderForm: { totalizers },
   } = useOrderForm()
+
+  const valueWithDiscount =
+    Number(totalizers[0].value) + Number(totalizers[1].value)
 
   const handleUpdateMinicartValue = useCallback(
     val => {
@@ -37,15 +40,15 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   )
 
   useEffect(() => {
-    handleUpdateMinicartValue(value)
-  }, [handleUpdateMinicartValue, value])
+    handleUpdateMinicartValue(valueWithDiscount)
+  }, [handleUpdateMinicartValue, valueWithDiscount])
 
   return (
     <div className={styles.freigthScaleContainer}>
       {differenceBetwenValues === settings.freeShippingAmount ? (
         <div className={styles.text0}>
           <FormattedMessage id="store/minicartbar.text0" />
-          <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />!
+          <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />
         </div>
       ) : (
         <>
@@ -77,7 +80,6 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
                 <FormattedCurrency
                   value={Math.max(0, differenceBetwenValues)}
                 />
-                !
               </span>
             </p>
           ) : (
@@ -100,9 +102,12 @@ const MinicartFreeshipping: FunctionComponent = () => {
 
   if (!settings.freeShippingAmount) {
     console.warn('No Free Shipping amount set')
-
     return null
   }
   return <MinimumFreightValue settings={settings} />
 }
 export default MinicartFreeshipping
+
+
+
+Hola! Somos dos chicas y trabajamos en empresas de tecnología en Barcelona. Estamos buscando un piso para nosotras y dos y nos interesaría ver el piso. Cuando podíamos pasar a verlo? Gracias y un saludo!

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -48,7 +48,7 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
       {differenceBetwenValues === settings.freeShippingAmount ? (
         <div className={styles.text0}>
           <FormattedMessage id="store/minicartbar.text0" />
-          <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />
+          <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />!
         </div>
       ) : (
         <>


### PR DESCRIPTION
#### What does this PR do? \*

This changes the value of the remaining value left for the customer to avail of the free shipping by subtracting the total value of the cart minus the total discounts in the cart.

This PR should fix the following problem that has been reported: 

![image (14)](https://user-images.githubusercontent.com/44602686/106868206-c9cec700-66ce-11eb-8e8c-ee7189e8d9e9.png)

#### How to test it? \*

Add items with discounts on a cart. Check and see if the remaining value left to avail of free shipping is correct. Value should be the total amount minus the discounts.
