### PR TITLE
Fix bug reported regarding totalizers with tax

### DIFF
--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -36,9 +36,11 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
     [settings.freeShippingAmount]
   )
 
-  const valueWithDiscount = value
-    ? Number(totalizers[0]?.value) + Number(totalizers[1]?.value)
-    : value
+  const getValues = (nameValue) => totalizers?.find(({ name }) => name === nameValue)?.value 
+  const discountTotal = getValues("Discounts Total")
+  const valueWithDiscount = !discountTotal
+    ? value
+    : getValues("Items Total") + (!discountTotal ? 0 : discountTotal)
 
   useEffect(() => {
     handleUpdateMinicartValue(valueWithDiscount)

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -36,15 +36,16 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
     [settings.freeShippingAmount]
   )
 
-  const getValues = (nameValue) => totalizers?.find(({ name }) => name === nameValue)?.value 
-  const discountTotal = getValues("Discounts Total")
+  const getValues = (idValue) => totalizers?.find(({ id }) => id === idValue)?.value 
+  const discountTotal = getValues("Discounts")
   const valueWithDiscount = !discountTotal
     ? value
-    : getValues("Items Total") + (!discountTotal ? 0 : discountTotal)
+    : getValues("Items") + (!discountTotal ? 0 : discountTotal)
+  const valueWithoutShipping = !getValues("Shipping") ? getValues("Shipping") : 0
 
   useEffect(() => {
-    handleUpdateMinicartValue(valueWithDiscount)
-  }, [handleUpdateMinicartValue, valueWithDiscount])
+    handleUpdateMinicartValue(valueWithDiscount - valueWithoutShipping)
+  }, [handleUpdateMinicartValue, valueWithDiscount, valueWithoutShipping])
 
   return (
     <div className={styles.freigthScaleContainer}>


### PR DESCRIPTION
Fixed bug reported regarding totalizers with tax by finding explicity object with tax and items total.

#### What does this PR do? \*

This fixes the issue of value being incorrect when the totalizer array has taxes. To fix this we explicitly find the discounts in the array and the items total. If there is no discount, value will be calculated as previously done thus fixing the issue.

#### How to test it? \*

Add items in the cart that has tax in the totalizer array. See if the final value is correct.