### PR TITLE
Fix: Remove shipping cost from logic to get final amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Doesn't consider `Shipping cost` from `Totalizers` to calculate amount to compare to free shipping amount.
+
 ## [1.1.4] - 2021-03-16
 
 ### Fixed

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -15,7 +15,7 @@ interface Settings {
   freeShippingAmount: number
 }
 
-type ValueTypes = 'Discounts' | 'Items' | 'Shipping'
+type ValueTypes = 'Discounts' | 'Items'
 
 const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   settings,
@@ -37,8 +37,7 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   const getValues = (idValue: ValueTypes): number =>
     totalizers?.find(({ id }) => id === idValue)?.value ?? 0
 
-  const finalValue =
-    getValues('Items') + getValues('Discounts') - getValues('Shipping')
+  const finalValue = getValues('Items') + getValues('Discounts')
 
   useEffect(() => {
     handleUpdateMinicartValue(finalValue)


### PR DESCRIPTION
#### What does this PR do? \*

Remove the shipping cost from the final amount to compare to free shipping amount. 

#### How to test it? \*

In [this workspace](https://fixfreeshipping--unileverytu.myvtex.com/)
