### PR TITLE
Add multiple binding free shipping amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for multiple binding stores to have different free shipping components for each binding
+
 ## [1.1.5] - 2021-03-22
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -43,28 +43,6 @@
         "title": "Free Shipping Amount",
         "description": "Enter the minimum amount for free shipping",
         "type": "number"
-      },
-      "isMultiBindingStore": {
-        "title": "Multiple bindings?",
-        "type": "boolean",
-        "default": false
-      },
-      "freeShippingAmounts": {
-        "title": "Multiple Binding Shipping Amounts",
-        "type": "array",
-        "items": {
-          "properties": {
-            "bindingId": {
-              "title": "Binding ID",
-              "type": "string"
-            },
-            "freeShippingAmount": {
-              "title": "Free Shipping Amount",
-              "type": "number",
-              "description": "Enter the minimum amount for free shipping"
-            }
-          }
-        }
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "dependencies": {
     "vtex.order-manager": "0.x",
@@ -39,6 +37,7 @@
   "settingsSchema": {
     "title": "Minicart Free Shipping progress",
     "type": "object",
+    "bindingBounded": true,
     "properties": {
       "freeShippingAmount": {
         "title": "Free Shipping Amount",
@@ -69,8 +68,6 @@
       }
     }
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,28 @@
         "title": "Free Shipping Amount",
         "description": "Enter the minimum amount for free shipping",
         "type": "number"
+      },
+      "isMultiBindingStore": {
+        "title": "Multiple bindings?",
+        "type": "boolean",
+        "default": false
+      },
+      "freeShippingAmounts": {
+        "title": "Multiple Binding Shipping Amounts",
+        "type": "array",
+        "items": {
+          "properties": {
+            "bindingId": {
+              "title": "Binding ID",
+              "type": "string"
+            },
+            "freeShippingAmount": {
+              "title": "Free Shipping Amount",
+              "type": "number",
+              "description": "Enter the minimum amount for free shipping"
+            }
+          }
+        }
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,9 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "dependencies": {
     "vtex.order-manager": "0.x",
@@ -46,6 +48,8 @@
       }
     }
   },
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -22,13 +22,6 @@ interface BindingBoundedSettings extends Settings {
 interface Settings {
   bindingId: string
   freeShippingAmount: number
-  isMultiBindingStore: boolean
-  freeShippingAmounts: [FreeShippingAmounts]
-}
-
-interface FreeShippingAmounts {
-  bindingId: string
-  freeShippingAmount: number
 }
 
 type ValueTypes = 'Discounts' | 'Items'

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -121,6 +121,7 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
 
 const MinicartFreeshipping: FunctionComponent = () => {
   const { data } = useQuery(AppSettings, { ssr: false })
+  const { binding } = useRuntime()
 
   if (!data?.appSettings?.message) return null
 
@@ -132,7 +133,11 @@ const MinicartFreeshipping: FunctionComponent = () => {
     return null
   }
 
-  if (settings.bindingBounded && !settings.settings?.[0].freeShippingAmount) {
+  const isAmountSetForBinding = settings.settings?.find(
+    item => item.bindingId === binding?.id
+  )?.freeShippingAmount
+
+  if (settings.bindingBounded && !isAmountSetForBinding) {
     console.warn('No Free Shipping amounts for multi binding store set')
 
     return null

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -16,7 +16,6 @@ interface SettingsProps {
 interface BindingBoundedSettings extends Settings {
   bindingBounded?: boolean
   settings?: [Settings]
-  freeShippingAmount: number
 }
 
 interface Settings {


### PR DESCRIPTION
#### What does this PR do? \*

This PR handles the case when the store has multiple bindings and wants to set a free shipping amount for each individual binding. With the current version, the free shipping amount in the app's settings would apply to all bindings.

Also, it hides the text1 and text2 above the completion bar because it's not OK to display "Complete your order to have FREE SHIPPING" when the free shipping amount has already been hit.  If you'd rather have me add a boolean prop as well to allow some stores to keep these messages up there regardless of whether or not the shipping amount has been hit, let me know

#### How to test it? \*

The app settings has two extra options

isMultiBindingStore boolean which if checked tells the code to default to the values inside the freeShippingAmounts array
freeShippingAmounts array which consists of objects with bindingId and freeShippingAmount for each object

I've attached some screenshots below as well to see the difference

This one is for B2B binding - I've set the amount to 352.1

![image](https://user-images.githubusercontent.com/71461884/137962153-a50777fe-919f-46db-ba38-0b01447cb26d.png)

This one is for B2C binding - I've set the amount to 252.1

![image](https://user-images.githubusercontent.com/71461884/137962216-e6c3e341-4cd9-409f-aedf-7978ef0c569b.png)


#### Describe alternatives you've considered, if any. \*

No alternatives as this is a feature the app didn't have.  Conditional layout again wasn't an option because the free shipping amount is taken from the app's settings so it had to be done at app level, not at store-theme level.
