### PR TITLE
add custom message with IOMessageWithMarkers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.format-currency": "0.x",
     "vtex.store-graphql": "2.x",
-    "vtex.apps-graphql": "2.x"
+    "vtex.apps-graphql": "2.x",
+    "vtex.native-types": "0.x"
   },
   "settingsSchema": {
     "title": "Minicart Free Shipping progress",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,7 @@
 {
-  "store/minicartbar.text0": "We have free shipping from: ",
+  "store/minicartbar.text0": "We have free shipping from: {diference}!",
   "store/minicartbar.text1": "Complete your order to have",
   "store/minicartbar.text2": "FREE shipping",
-  "store/minicartbar.text3": "Only left",
+  "store/minicartbar.text3": "Only left {diference}!",
   "store/minicartbar.text4": "You won free shipping"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,7 @@
 {
-  "store/minicartbar.text0": "Tenemos envío gratis desde: ",
+  "store/minicartbar.text0": "Tenemos envío gratis desde: {diference}!",
   "store/minicartbar.text1": "¡Completa tu pedido para tener",
   "store/minicartbar.text2": "Envio GRATIS 24!",
-  "store/minicartbar.text3": "¡Solo te quedan",
+  "store/minicartbar.text3": "¡Solo te quedan {diference}!",
   "store/minicartbar.text4": "¡Ganaste envío gratis!"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,7 +1,7 @@
 {
-  "store/minicartbar.text0": "SPEDIZIONE GRATUITA per ordini sopra: ",
+  "store/minicartbar.text0": "SPEDIZIONE GRATUITA per ordini sopra: {diference}!",
   "store/minicartbar.text1": "Completa il tuo ordine per usufruire della",
   "store/minicartbar.text2": "SPEDIZIONE GRATUITA",
-  "store/minicartbar.text3": "Per usufruire della SPEDIZIONE GRATUITA mancano solo: ",
+  "store/minicartbar.text3": "Per usufruire della SPEDIZIONE GRATUITA mancano solo: {diference}!",
   "store/minicartbar.text4": "Hai diritto alla SPEDIZIONE GRATUITA!"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,7 +1,7 @@
 {
-  "store/minicartbar.text0": "Temos frete grátis de:",
+  "store/minicartbar.text0": "Temos frete grátis de: {diference}!",
   "store/minicartbar.text1": "Complete seu pedido para ter",
   "store/minicartbar.text2": "Frete GRÁTIS 24h",
-  "store/minicartbar.text3": "Só faltam",
+  "store/minicartbar.text3": "Só faltam {diference}!",
   "store/minicartbar.text4": "Você ganhou frete grátis!"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,7 +1,7 @@
 {
-  "store/minicartbar.text0": "Avem livrare gratuită la: ",
+  "store/minicartbar.text0": "Avem livrare gratuită la: {diference}!",
   "store/minicartbar.text1": "Completați comanda dvs. pentru ",
   "store/minicartbar.text2": "Livrare GRATUITĂ",
-  "store/minicartbar.text3": "Au rămas doar",
+  "store/minicartbar.text3": "Au rămas doar {diference}!",
   "store/minicartbar.text4": "Ai câștigat livrare gratuită"
 }

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -5,11 +5,17 @@ import { useRuntime } from 'vtex.render-runtime'
 import { useQuery } from 'react-apollo'
 import { FormattedMessage } from 'react-intl'
 import { FormattedCurrency } from 'vtex.format-currency'
+import { IOMessageWithMarkers } from 'vtex.native-types'
 
 import styles from './MinicartFreeshipping.css'
 import AppSettings from './minicartbarSettings.graphql'
 
-interface SettingsProps {
+interface MinicartFreeshippingProps {
+  markers?: string[]
+  emptyCartMessage?: string
+  message?: string
+}
+interface SettingsProps extends MinicartFreeshippingProps {
   settings: BindingBoundedSettings
 }
 
@@ -27,6 +33,9 @@ type ValueTypes = 'Discounts' | 'Items'
 
 const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   settings,
+  markers = [],
+  emptyCartMessage = "store/minicartbar.text0 {diference}",
+  message = "store/minicartbar.text3"
 }) => {
   const { binding } = useRuntime()
   const [shippingFreePercentage, setShippingFreePercentage] = useState(0)
@@ -69,8 +78,16 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
     <div className={styles.freigthScaleContainer}>
       {differenceBetwenValues === freeShippingAmount ? (
         <div className={styles.text0}>
-          <FormattedMessage id="store/minicartbar.text0" />
-          <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />!
+          <IOMessageWithMarkers 
+                message={emptyCartMessage}
+                markers={markers}
+                handleBase="currency" 
+                values={{
+                  diference: (
+                    <FormattedCurrency value={Math.max(0, differenceBetwenValues)} />
+                  )
+                }}
+              />
         </div>
       ) : (
         <>
@@ -97,14 +114,19 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
           {differenceBetwenValues > 0 ? (
             <p className={styles.sliderText}>
               <span className={styles.text3}>
-                <FormattedMessage id="store/minicartbar.text3" />{' '}
-              </span>
-
-              <span className={styles.currencyText}>
-                <FormattedCurrency
-                  value={Math.max(0, differenceBetwenValues)}
-                />
-                !
+              <IOMessageWithMarkers 
+                message={message}
+                markers={markers}
+                handleBase="currency" 
+                values={{
+                  diference: (
+                  <span className={styles.currencyText}>
+                    <FormattedCurrency
+                      value={Math.max(0, differenceBetwenValues)}
+                    />
+                  </span>)
+                }}
+              />
               </span>
             </p>
           ) : (
@@ -118,7 +140,7 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
   )
 }
 
-const MinicartFreeshipping: FunctionComponent = () => {
+const MinicartFreeshipping: FunctionComponent<MinicartFreeshippingProps> = ({message, emptyCartMessage,markers }) => {
   const { data } = useQuery(AppSettings, { ssr: false })
   const { binding } = useRuntime()
 
@@ -142,7 +164,7 @@ const MinicartFreeshipping: FunctionComponent = () => {
     return null
   }
 
-  return <MinimumFreightValue settings={settings} />
+  return <MinimumFreightValue settings={settings} markers={markers} emptyCartMessage={emptyCartMessage} message={message}/>
 }
 
 export default MinicartFreeshipping


### PR DESCRIPTION
#### What does this PR do? \*

this PR allows to use custom message with no fixed place to currency.

#### How to test it? \*

Add `minicart-bar` block in your store, and pass the props `message` to custom message when have product in cart. `enptyCartMessage` to when no products in cart and markers to create markers.

