### PR TITLE
chore: uses `publicSettingsForApp` endpoint to retrieve app settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Uses `publicSettingsForApp` endpoint to retrieve app settings
+
 ## [2.0.3] - 2022-08-17
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,7 @@
     "vtex.session-client": "1.x"
   },
   "settingsSchema": {
+  "access": "public",
     "title": "Minicart Free Shipping progress",
     "type": "object",
     "bindingBounded": true,

--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,7 @@
     "vtex.session-client": "1.x"
   },
   "settingsSchema": {
-  "access": "public",
+    "access": "public",
     "title": "Minicart Free Shipping progress",
     "type": "object",
     "bindingBounded": true,

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,7 @@
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.format-currency": "0.x",
     "vtex.store-graphql": "2.x",
-    "vtex.apps-graphql": "2.x",
+    "vtex.apps-graphql": "3.x",
     "vtex.session-client": "1.x"
   },
   "settingsSchema": {

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -138,8 +138,8 @@ const MinicartFreeshipping: FunctionComponent = () => {
   const { data } = useQuery(AppSettings, { ssr: false })
   const { binding } = useRuntime()
 
-  if (!data?.appSettings?.message) return null
-  const settings = JSON.parse(data.appSettings.message)
+  if (!data?.publicSettingsForApp?.message) return null
+  const settings = JSON.parse(data.publicSettingsForApp.message)
 
   if (!settings.bindingBounded && !settings.freeShippingTradePolicies[0].freeShippingAmount) {
     console.warn('No Free Shipping amount set')

--- a/react/components/minicartbarSettings.graphql
+++ b/react/components/minicartbarSettings.graphql
@@ -1,5 +1,5 @@
 query AppSettings {
-  appSettings(app: "vtexeurope.minicart-freeshipping-bar", version: "2.x")
+  publicSettingsForApp(app: "vtexeurope.minicart-freeshipping-bar", version: "2.x")
     @context(provider: "vtex.apps-graphql") {
     message
   }


### PR DESCRIPTION
This PR uses the [new endpoint at apps-graphql](https://github.com/vtex/apps-graphql/blob/v3.x/graphql/schema.graphql#L46) to retrieve public settings from apps.