### PR TITLE
Fix/apps settings retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Settings schema properties structure
 
 ## [2.1.0] - 2023-02-24
 

--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "dependencies": {
     "vtex.order-manager": "0.x",
@@ -38,11 +36,11 @@
     "vtex.session-client": "1.x"
   },
   "settingsSchema": {
-    "access": "public",
     "title": "Minicart Free Shipping progress",
     "type": "object",
-    "bindingBounded": true,
+    "access": "public",
     "properties": {
+      "bindingBounded": true,
       "freeShippingTradePolicies": {
         "title": "Trade Policies",
         "description": "Free shipping per trade policies",
@@ -64,8 +62,6 @@
       }
     }
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What does this PR do? \*

Fixes the settings schema. After deploying the last version with the changes from PR #21 an error occurred on the minicart. It was because the place where `bindingBounded` was being defined on the schema was making the [Apps infra](https://github.com/vtex/node-vtex-api/blob/08ea11d380997f5abf02455487b342caa74b2001/src/clients/infra/Apps.ts#L453) return only the `bindingBounded` as properties from this app - so we couldn't get the other public property through the new version of [vtex.apps-graphql](https://github.com/vtex/apps-graphql/blob/e579730c9f171a2f1ddfabb67acf0b7184da6fa5/node/graphql/resolvers/query/publicSettingsForApp.ts#L14).
This was the error thrown:
![image](https://user-images.githubusercontent.com/19983991/221251804-18bcc19e-55f1-48a2-9387-df81d4fb8d52.png)

#### How to test it? \*
Add this [product](https://laricia--worldwidegolf.myvtex.com/garmin-approach-s62-gps-watch-600000576/p) to cart and as you open the minicart see that no error is thrown.

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
