### PR TITLE
Chore: uses publicSettingsForApp endpoint to retrieve app settings (1.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `vtex.apps-graphql` dependency to `3.x` and use new `publicSettingsForApp` query to get settings
+
 ## [1.2.0] - 2022-03-21
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "dependencies": {
     "vtex.order-manager": "0.x",
@@ -34,11 +32,12 @@
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.format-currency": "0.x",
     "vtex.store-graphql": "2.x",
-    "vtex.apps-graphql": "2.x"
+    "vtex.apps-graphql": "3.x"
   },
   "settingsSchema": {
     "title": "Minicart Free Shipping progress",
     "type": "object",
+    "access": "public",
     "bindingBounded": true,
     "properties": {
       "freeShippingAmount": {
@@ -48,8 +47,6 @@
       }
     }
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -122,9 +122,9 @@ const MinicartFreeshipping: FunctionComponent = () => {
   const { data } = useQuery(AppSettings, { ssr: false })
   const { binding } = useRuntime()
 
-  if (!data?.appSettings?.message) return null
+  if (!data?.publicSettingsForApp?.message) return null
 
-  const settings = JSON.parse(data.appSettings.message)
+  const settings = JSON.parse(data.publicSettingsForApp.message)
 
   if (!settings.bindingBounded && !settings.freeShippingAmount) {
     console.warn('No Free Shipping amount set')

--- a/react/components/minicartbarSettings.graphql
+++ b/react/components/minicartbarSettings.graphql
@@ -1,7 +1,8 @@
 query AppSettings {
-  appSettings(app: "vtexeurope.minicart-freeshipping-bar", version: "1.x")
-    @context(provider: "vtex.apps-graphql") {
+  publicSettingsForApp(
+    app: "vtexeurope.minicart-freeshipping-bar"
+    version: "1.x"
+  ) @context(provider: "vtex.apps-graphql") {
     message
-
   }
 }


### PR DESCRIPTION
#### What does this PR do? \*

This PR uses the [new endpoint at apps-graphql](https://github.com/vtex/apps-graphql/blob/v3.x/graphql/schema.graphql#L46) to retrieve public settings from apps. 

This is to update the `1.x` major of the app (the `2.x` major has already been updated).

#### How to test it? \*

Linked here: https://freeshipsettings--budgetgolf.myvtex.com
