### PR TITLE
fix: remove cache from settings query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.2] - 2023-03-06
 ### Fixed
+
+- Changed settings query to have 'no-cache' fetching policy
+
+## [2.1.2] - 2023-03-06
+
+### Fixed
+
 - Revert 2.1.1
 
 ## [2.1.1] - 2023-02-24
+
 ### Fixed
+
 - Settings schema properties structure
 
 ## [2.1.0] - 2023-02-24

--- a/manifest.json
+++ b/manifest.json
@@ -17,9 +17,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "dependencies": {
     "vtex.order-manager": "0.x",
@@ -64,8 +62,6 @@
       }
     }
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }


### PR DESCRIPTION
#### What does this PR do? \*

- Changed useQuery settings to have a no-cache policy so that promotions set by the customer would affect the app faster

#### How to test it? \*

- Change value of FreeShippingAmount and test in front-end. Change should be reflected immediately. See workspace: https://minicart--budgetgolf.myvtex.com/


#### Related to / Depends on \*

Customer ticket #825335 on Zendesk
