### PR TITLE
fix: app settings graphQL cache issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed settings query to have 'no-cache' fetching policy
+
 ## [1.2.1] - 2023-03-06
 
 ### Changed

--- a/react/components/MinicartFreeshipping.tsx
+++ b/react/components/MinicartFreeshipping.tsx
@@ -119,7 +119,11 @@ const MinimumFreightValue: FunctionComponent<SettingsProps> = ({
 }
 
 const MinicartFreeshipping: FunctionComponent = () => {
-  const { data } = useQuery(AppSettings, { ssr: false })
+  const { data } = useQuery(AppSettings, {
+    ssr: false,
+    fetchPolicy: 'no-cache',
+  })
+
   const { binding } = useRuntime()
 
   if (!data?.publicSettingsForApp?.message) return null


### PR DESCRIPTION
What does this PR do? *

Changed useQuery settings to have a no-cache policy so that promotions set by the customer would affect the app faster

How to test it? *

Change value of FreeShippingAmount and test in front-end. Change should be reflected immediately. See workspace: https://minicart--budgetgolf.myvtex.com/

Related to / Depends on *

Customer ticket #825335 on Zendesk